### PR TITLE
fix: classes in recipes should not inherit from CategoricalVariant

### DIFF
--- a/src/ga4gh/cat_vrs/recipes.py
+++ b/src/ga4gh/cat_vrs/recipes.py
@@ -38,6 +38,8 @@ class _CategoricalVariantValidatorMixin:
     Should be used with classes that inherit from Pydantic BaseModel
     """
 
+    model_config = ConfigDict(extra="allow")
+
     @model_validator(mode="after")
     def categorical_variant_validator(cls, model: BaseModel) -> BaseModel:  # noqa: N805
         """Validate that the model is a ``CategoricalVariant``.
@@ -63,8 +65,6 @@ class ProteinSequenceConsequence(BaseModel, _CategoricalVariantValidatorMixin):
     that is representative of a collection of congruent Protein Alleles that share the
     same altered codon(s).
     """
-
-    model_config = ConfigDict(extra="allow")
 
     constraints: list[Constraint] = Field(..., min_length=1)
 
@@ -112,8 +112,6 @@ class CanonicalAllele(BaseModel, _CategoricalVariantValidatorMixin):
     representations of an Allele often exist across different genome assemblies and
     associated cDNA transcript representations.
     """
-
-    model_config = ConfigDict(extra="allow")
 
     constraints: list[Constraint] = Field(..., min_length=1, max_length=1)
 
@@ -179,8 +177,6 @@ class CanonicalAllele(BaseModel, _CategoricalVariantValidatorMixin):
 
 class CategoricalCnv(BaseModel, _CategoricalVariantValidatorMixin):
     """A representation of the constraints for matching knowledge about CNVs."""
-
-    model_config = ConfigDict(extra="allow")
 
     constraints: list[Constraint] = Field(
         ...,

--- a/src/ga4gh/cat_vrs/recipes.py
+++ b/src/ga4gh/cat_vrs/recipes.py
@@ -15,7 +15,14 @@ from ga4gh.cat_vrs.models import (
     DefiningLocationConstraint,
     Relation,
 )
-from pydantic import Field, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 
 class SystemUri(str, Enum):
@@ -25,7 +32,29 @@ class SystemUri(str, Enum):
     GKS_ALLELE_RELATION = "ga4gh-gks-term:allele-relation"
 
 
-class ProteinSequenceConsequence(CategoricalVariant):
+class _CategoricalVariantValidatorMixin:
+    """Mixin class for reusable CategoricalVariant model validators
+
+    Should be used with classes that inherit from Pydantic BaseModel
+    """
+
+    @model_validator(mode="after")
+    def categorical_variant_validator(cls, model: BaseModel) -> BaseModel:  # noqa: N805
+        """Validate that the model is a ``CategoricalVariant``.
+
+        :param model: Pydantic BaseModel to validate
+        :raises ValueError: If ``model`` does not validate against a ``CategoricalVariant``
+        :return: Validated model
+        """
+        try:
+            CategoricalVariant(**model.model_dump())
+        except ValidationError as e:
+            err_msg = "Must be a `CategoricalVariant`"
+            raise ValueError(err_msg) from e
+        return model
+
+
+class ProteinSequenceConsequence(BaseModel, _CategoricalVariantValidatorMixin):
     """A change that occurs in a protein sequence as a result of genomic changes. Due to
     the degenerate nature of the genetic code, there are often several genomic changes
     that can cause a protein sequence consequence. The protein sequence consequence,
@@ -34,6 +63,8 @@ class ProteinSequenceConsequence(CategoricalVariant):
     that is representative of a collection of congruent Protein Alleles that share the
     same altered codon(s).
     """
+
+    model_config = ConfigDict(extra="allow")
 
     constraints: list[Constraint] = Field(..., min_length=1)
 
@@ -73,7 +104,7 @@ class ProteinSequenceConsequence(CategoricalVariant):
         return v
 
 
-class CanonicalAllele(CategoricalVariant):
+class CanonicalAllele(BaseModel, _CategoricalVariantValidatorMixin):
     """A canonical allele is defined by an
     `Allele <https://vrs.ga4gh.org/en/2.x/concepts/MolecularVariation/Allele.html#>`_
     that is representative of a collection of congruent Alleles, each of which depict
@@ -81,6 +112,8 @@ class CanonicalAllele(CategoricalVariant):
     representations of an Allele often exist across different genome assemblies and
     associated cDNA transcript representations.
     """
+
+    model_config = ConfigDict(extra="allow")
 
     constraints: list[Constraint] = Field(..., min_length=1, max_length=1)
 
@@ -144,8 +177,10 @@ class CanonicalAllele(CategoricalVariant):
         return v
 
 
-class CategoricalCnv(CategoricalVariant):
+class CategoricalCnv(BaseModel, _CategoricalVariantValidatorMixin):
     """A representation of the constraints for matching knowledge about CNVs."""
+
+    model_config = ConfigDict(extra="allow")
 
     constraints: list[Constraint] = Field(
         ...,

--- a/src/ga4gh/cat_vrs/recipes.py
+++ b/src/ga4gh/cat_vrs/recipes.py
@@ -32,7 +32,7 @@ class SystemUri(str, Enum):
     GKS_ALLELE_RELATION = "ga4gh-gks-term:allele-relation"
 
 
-class _CategoricalVariantValidatorMixin:
+class CategoricalVariantValidatorMixin:
     """Mixin class for reusable CategoricalVariant model validators
 
     Should be used with classes that inherit from Pydantic BaseModel
@@ -56,7 +56,7 @@ class _CategoricalVariantValidatorMixin:
         return model
 
 
-class ProteinSequenceConsequence(BaseModel, _CategoricalVariantValidatorMixin):
+class ProteinSequenceConsequence(BaseModel, CategoricalVariantValidatorMixin):
     """A change that occurs in a protein sequence as a result of genomic changes. Due to
     the degenerate nature of the genetic code, there are often several genomic changes
     that can cause a protein sequence consequence. The protein sequence consequence,
@@ -104,7 +104,7 @@ class ProteinSequenceConsequence(BaseModel, _CategoricalVariantValidatorMixin):
         return v
 
 
-class CanonicalAllele(BaseModel, _CategoricalVariantValidatorMixin):
+class CanonicalAllele(BaseModel, CategoricalVariantValidatorMixin):
     """A canonical allele is defined by an
     `Allele <https://vrs.ga4gh.org/en/2.x/concepts/MolecularVariation/Allele.html#>`_
     that is representative of a collection of congruent Alleles, each of which depict
@@ -175,7 +175,7 @@ class CanonicalAllele(BaseModel, _CategoricalVariantValidatorMixin):
         return v
 
 
-class CategoricalCnv(BaseModel, _CategoricalVariantValidatorMixin):
+class CategoricalCnv(BaseModel, CategoricalVariantValidatorMixin):
     """A representation of the constraints for matching knowledge about CNVs."""
 
     constraints: list[Constraint] = Field(

--- a/tests/validation/test_cat_vrs_models.py
+++ b/tests/validation/test_cat_vrs_models.py
@@ -84,8 +84,7 @@ def test_copy_change_constraint():
 def test_protein_sequence_consequence(defining_loc_constr, members):
     """Test the ProteinSequenceConsequence validator"""
     # Valid PSC
-    valid_params = deepcopy(members)
-    valid_params["constraints"] = [
+    constraints = [
         models.Constraint(
             root=models.DefiningAlleleConstraint(
                 relations=[
@@ -100,7 +99,15 @@ def test_protein_sequence_consequence(defining_loc_constr, members):
             )
         )
     ]
+    valid_params = deepcopy(members)
+    valid_params["constraints"] = constraints
     assert recipes.ProteinSequenceConsequence(**valid_params)
+
+    # Invalid PSC: Not a CategoricalVariant
+    with pytest.raises(ValueError, match=r"Must be a `CategoricalVariant`"):
+        recipes.ProteinSequenceConsequence(
+            constraints=constraints, type="ProteinSequenceConsequence"
+        )
 
     # Invalid PSC: Constraint is NOT DefiningAlleleContext
     err_msg = "Unable to find at least one constraint that is a"
@@ -189,7 +196,7 @@ def test_canonical_allele(defining_loc_constr, members):
     """Test the CanonicalAllele validator"""
     # Valid CanonicalAllele
     valid_params = deepcopy(members)
-    valid_params["constraints"] = [
+    constraints = [
         models.Constraint(
             root=models.DefiningAlleleConstraint(
                 relations=[
@@ -210,7 +217,12 @@ def test_canonical_allele(defining_loc_constr, members):
             )
         )
     ]
+    valid_params["constraints"] = constraints
     assert recipes.CanonicalAllele(**valid_params)
+
+    # Invalid CanonicalAllele: Not a CategoricalVariant
+    with pytest.raises(ValueError, match=r"Must be a `CategoricalVariant`"):
+        recipes.CanonicalAllele(constraints=constraints, type="CanonicalAllele")
 
     # Invalid CanonicalAllele: Constraint is NOT DefiningAlleleContext
     valid_params = deepcopy(members)
@@ -377,11 +389,16 @@ def test_categorical_cnv(members, defining_loc_constr, copy_change_constr):
 
     # Valid CategoricalCnv with CopyCountConstraint
     valid_params = deepcopy(members)
-    valid_params["constraints"] = [
+    constraints = [
         models.Constraint(root=defining_loc_constr),
         models.Constraint(root=models.CopyCountConstraint(copies=[1, 2])),
     ]
+    valid_params["constraints"] = constraints
     assert recipes.CategoricalCnv(**valid_params)
+
+    # Invalid CategoricalCnv: Not a CategoricalVariant
+    with pytest.raises(ValueError, match=r"Must be a `CategoricalVariant`"):
+        recipes.CategoricalCnv(constraints=constraints, type="CategoricalCnv")
 
     # Invalid CategoricalCnv: No DefiningLocationConstraint
     invalid_params = deepcopy(members)


### PR DESCRIPTION
close #16

* `ProteinSequenceConsequence`, `CanonicalAllele`, and `CategoricalCnv` should NOT inherit from `CategoricalVariant`. Instead, they should have use a `model_validator`
* Additional properties are now allowed in recipes