### PR TITLE
revert: "fix: classes in recipes should not inherit from CategoricalVariant (#17)"

### DIFF
--- a/src/ga4gh/cat_vrs/recipes.py
+++ b/src/ga4gh/cat_vrs/recipes.py
@@ -15,14 +15,7 @@ from ga4gh.cat_vrs.models import (
     DefiningLocationConstraint,
     Relation,
 )
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    ValidationError,
-    field_validator,
-    model_validator,
-)
+from pydantic import Field, field_validator
 
 
 class SystemUri(str, Enum):
@@ -32,31 +25,7 @@ class SystemUri(str, Enum):
     GKS_ALLELE_RELATION = "ga4gh-gks-term:allele-relation"
 
 
-class CategoricalVariantValidatorMixin:
-    """Mixin class for reusable CategoricalVariant model validators
-
-    Should be used with classes that inherit from Pydantic BaseModel
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    @model_validator(mode="after")
-    def categorical_variant_validator(cls, model: BaseModel) -> BaseModel:  # noqa: N805
-        """Validate that the model is a ``CategoricalVariant``.
-
-        :param model: Pydantic BaseModel to validate
-        :raises ValueError: If ``model`` does not validate against a ``CategoricalVariant``
-        :return: Validated model
-        """
-        try:
-            CategoricalVariant(**model.model_dump())
-        except ValidationError as e:
-            err_msg = "Must be a `CategoricalVariant`"
-            raise ValueError(err_msg) from e
-        return model
-
-
-class ProteinSequenceConsequence(BaseModel, CategoricalVariantValidatorMixin):
+class ProteinSequenceConsequence(CategoricalVariant):
     """A change that occurs in a protein sequence as a result of genomic changes. Due to
     the degenerate nature of the genetic code, there are often several genomic changes
     that can cause a protein sequence consequence. The protein sequence consequence,
@@ -104,7 +73,7 @@ class ProteinSequenceConsequence(BaseModel, CategoricalVariantValidatorMixin):
         return v
 
 
-class CanonicalAllele(BaseModel, CategoricalVariantValidatorMixin):
+class CanonicalAllele(CategoricalVariant):
     """A canonical allele is defined by an
     `Allele <https://vrs.ga4gh.org/en/2.x/concepts/MolecularVariation/Allele.html#>`_
     that is representative of a collection of congruent Alleles, each of which depict
@@ -175,7 +144,7 @@ class CanonicalAllele(BaseModel, CategoricalVariantValidatorMixin):
         return v
 
 
-class CategoricalCnv(BaseModel, CategoricalVariantValidatorMixin):
+class CategoricalCnv(CategoricalVariant):
     """A representation of the constraints for matching knowledge about CNVs."""
 
     constraints: list[Constraint] = Field(

--- a/tests/validation/test_cat_vrs_models.py
+++ b/tests/validation/test_cat_vrs_models.py
@@ -84,7 +84,8 @@ def test_copy_change_constraint():
 def test_protein_sequence_consequence(defining_loc_constr, members):
     """Test the ProteinSequenceConsequence validator"""
     # Valid PSC
-    constraints = [
+    valid_params = deepcopy(members)
+    valid_params["constraints"] = [
         models.Constraint(
             root=models.DefiningAlleleConstraint(
                 relations=[
@@ -99,15 +100,7 @@ def test_protein_sequence_consequence(defining_loc_constr, members):
             )
         )
     ]
-    valid_params = deepcopy(members)
-    valid_params["constraints"] = constraints
     assert recipes.ProteinSequenceConsequence(**valid_params)
-
-    # Invalid PSC: Not a CategoricalVariant
-    with pytest.raises(ValueError, match=r"Must be a `CategoricalVariant`"):
-        recipes.ProteinSequenceConsequence(
-            constraints=constraints, type="ProteinSequenceConsequence"
-        )
 
     # Invalid PSC: Constraint is NOT DefiningAlleleContext
     err_msg = "Unable to find at least one constraint that is a"
@@ -196,7 +189,7 @@ def test_canonical_allele(defining_loc_constr, members):
     """Test the CanonicalAllele validator"""
     # Valid CanonicalAllele
     valid_params = deepcopy(members)
-    constraints = [
+    valid_params["constraints"] = [
         models.Constraint(
             root=models.DefiningAlleleConstraint(
                 relations=[
@@ -217,12 +210,7 @@ def test_canonical_allele(defining_loc_constr, members):
             )
         )
     ]
-    valid_params["constraints"] = constraints
     assert recipes.CanonicalAllele(**valid_params)
-
-    # Invalid CanonicalAllele: Not a CategoricalVariant
-    with pytest.raises(ValueError, match=r"Must be a `CategoricalVariant`"):
-        recipes.CanonicalAllele(constraints=constraints, type="CanonicalAllele")
 
     # Invalid CanonicalAllele: Constraint is NOT DefiningAlleleContext
     valid_params = deepcopy(members)
@@ -389,16 +377,11 @@ def test_categorical_cnv(members, defining_loc_constr, copy_change_constr):
 
     # Valid CategoricalCnv with CopyCountConstraint
     valid_params = deepcopy(members)
-    constraints = [
+    valid_params["constraints"] = [
         models.Constraint(root=defining_loc_constr),
         models.Constraint(root=models.CopyCountConstraint(copies=[1, 2])),
     ]
-    valid_params["constraints"] = constraints
     assert recipes.CategoricalCnv(**valid_params)
-
-    # Invalid CategoricalCnv: Not a CategoricalVariant
-    with pytest.raises(ValueError, match=r"Must be a `CategoricalVariant`"):
-        recipes.CategoricalCnv(constraints=constraints, type="CategoricalCnv")
 
     # Invalid CategoricalCnv: No DefiningLocationConstraint
     invalid_params = deepcopy(members)


### PR DESCRIPTION
This reverts commit c38b457164091ba73fa86c2606a1b19daa430881.