### PR TITLE
build: tighten ga4gh.vrs version to >=2.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
-    "ga4gh.vrs>=2.0,<3.0",
+    "ga4gh.vrs>=2.1.3,<3.0",
     "pydantic>=2.0,<3.0",
 ]
 


### PR DESCRIPTION
This ensures Pydantic models are fully defined