### PR TITLE
test: fix pytest-cov settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,6 @@ where = ["src"]
 [tool.setuptools_scm]
 
 [tool.pytest.ini_options]
-addopts = "--cov-report=term-missing --cov=ga4gh"
-testpaths = ["tests", "src"]
+addopts = "--cov-report=term-missing --cov=ga4gh.cat_vrs"
+testpaths = ["tests"]
 doctest_optionflags = "ALLOW_UNICODE ALLOW_BYTES ELLIPSIS IGNORE_EXCEPTION_DETAIL NORMALIZE_WHITESPACE"


### PR DESCRIPTION
Currently, pytest-cov is evaluating coverage for the entire `ga4gh` namespace, which includes VRS-Python:

<img width="842" height="378" alt="Screenshot 2026-02-12 at 9 07 18 AM" src="https://github.com/user-attachments/assets/1fe46a4e-fb0c-45e6-b013-699cc91d59a7" />

Fixing the `--cov` parameter to be more specific solves this:

<img width="609" height="349" alt="Screenshot 2026-02-12 at 9 14 19 AM" src="https://github.com/user-attachments/assets/757cbbe4-40f6-4f95-bd01-75a7495c56b9" />

We also don't use doctests, so I updated the `testpaths` setting too