### PR TITLE
feat!: add predefined relations constants

### DIFF
--- a/src/ga4gh/cat_vrs/models.py
+++ b/src/ga4gh/cat_vrs/models.py
@@ -4,7 +4,6 @@ See the `CatVar page <https://www.ga4gh.org/product/categorical-variation-catvar
 the GA4GH website for more information.
 """
 
-from enum import Enum
 from typing import Literal
 
 from pydantic import Field, RootModel
@@ -17,16 +16,6 @@ from ga4gh.core.models import (
     iriReference,
 )
 from ga4gh.vrs.models import Allele, CopyChange, Range, SequenceLocation, Variation
-
-
-class Relation(str, Enum):
-    """Defined relationships between members of the categorical variant and the defining
-    context.
-    """
-
-    TRANSLATION_OF = "translation_of"
-    LIFTOVER_TO = "liftover_to"
-    TRANSCRIBED_TO = "transcribed_to"
 
 
 class DefiningAlleleConstraint(BaseModelForbidExtra):

--- a/src/ga4gh/cat_vrs/recipes.py
+++ b/src/ga4gh/cat_vrs/recipes.py
@@ -4,8 +4,6 @@ See the `CatVar page <https://www.ga4gh.org/product/categorical-variation-catvar
 the GA4GH website for more information.
 """
 
-from enum import Enum
-
 from pydantic import Field, field_validator
 
 from ga4gh.cat_vrs.models import (
@@ -15,15 +13,13 @@ from ga4gh.cat_vrs.models import (
     CopyCountConstraint,
     DefiningAlleleConstraint,
     DefiningLocationConstraint,
-    Relation,
 )
-
-
-class SystemUri(str, Enum):
-    """Define constraints for systems"""
-
-    SEQUENCE_ONTOLOGY = "http://www.sequenceontology.org"
-    GKS_ALLELE_RELATION = "ga4gh-gks-term:allele-relation"
+from ga4gh.cat_vrs.relations import (
+    LIFTOVER_TO_RELATION,
+    TRANSCRIBED_TO_RELATION,
+    TRANSLATION_OF_RELATION,
+)
+from ga4gh.core.models import MappableConcept
 
 
 class ProteinSequenceConsequence(CategoricalVariant):
@@ -38,6 +34,11 @@ class ProteinSequenceConsequence(CategoricalVariant):
 
     constraints: list[Constraint] = Field(..., min_length=1)
 
+    @classmethod
+    def required_relations(cls) -> list[MappableConcept]:
+        """Return relations required for defining allele constraints."""
+        return [TRANSLATION_OF_RELATION]
+
     @field_validator("constraints")
     @classmethod
     def validate_constraints(cls, v: list[Constraint]) -> list[Constraint]:
@@ -48,27 +49,22 @@ class ProteinSequenceConsequence(CategoricalVariant):
         1. Must be a ``DefiningAlleleConstraint``
         2. Must have ``relations`` property that meets ALL of the following
         requirements:
-            a. Must contain exactly one relation where ``primaryCoding.code = translation_of``
-               and ``primaryCoding.system = http://www.sequenceontology.org``
+            a. Must contain exactly one ``TRANSLATION_OF_RELATION``
 
         :param v: Constraints property to validate
         :raises ValueError: If constraints property does not satisfy the requirements
         :return: Constraints property
         """
+        required_relations = cls.required_relations()
+        required_relation = required_relations[0]
         if not any(
             isinstance(constraint.root, DefiningAlleleConstraint)
             and constraint.root.relations
-            and sum(
-                1
-                for r in constraint.root.relations
-                if r.primaryCoding
-                and r.primaryCoding.code.root == Relation.TRANSLATION_OF.value
-                and r.primaryCoding.system == SystemUri.SEQUENCE_ONTOLOGY.value
-            )
+            and sum(1 for r in constraint.root.relations if r in required_relations)
             == 1
             for constraint in v
         ):
-            err_msg = f"Unable to find at least one constraint that is a `DefiningAlleleConstraint` and has exactly one `relation` where the `primaryCoding.code` is '{Relation.TRANSLATION_OF.value}' and `primaryCoding.system` is '{SystemUri.SEQUENCE_ONTOLOGY.value}'."
+            err_msg = f"Unable to find at least one constraint that is a `DefiningAlleleConstraint` and has exactly one `relation` where the `primaryCoding.code` is '{required_relation.primaryCoding.code.root}' and `primaryCoding.system` is '{required_relation.primaryCoding.system}'."
             raise ValueError(err_msg)
 
         return v
@@ -85,6 +81,11 @@ class CanonicalAllele(CategoricalVariant):
 
     constraints: list[Constraint] = Field(..., min_length=1, max_length=1)
 
+    @classmethod
+    def required_relations(cls) -> list[MappableConcept]:
+        """Return relations required for canonical allele constraints."""
+        return [LIFTOVER_TO_RELATION, TRANSCRIBED_TO_RELATION]
+
     @field_validator("constraints")
     @classmethod
     def validate_constraints(cls, v: list[Constraint]) -> list[Constraint]:
@@ -95,8 +96,8 @@ class CanonicalAllele(CategoricalVariant):
         1. Must be a ``DefiningAlleleConstraint``
         2. Must have ``relations`` property that meets ALL of the following
         requirements:
-            a. Must contain exactly one relation where ``primaryCoding.code = liftover_to`` and ``primaryCoding.system == ga4gh-gks-term:allele-relation``
-            b. Must contain exactly one relation where ``primaryCoding.code = transcribed_to`` and ``primaryCoding.system == http://www.sequenceontology.org``
+            a. Must contain exactly one ``LIFTOVER_TO_RELATION``
+            b. Must contain exactly one ``TRANSCRIBED_TO_RELATION``
 
         :param v: Constraints property to validate
         :raises ValueError: If constraints property does not satisfy the requirements
@@ -112,35 +113,10 @@ class CanonicalAllele(CategoricalVariant):
             err_msg = "`relations` is required."
             raise ValueError(err_msg)
 
-        if (
-            sum(
-                1
-                for r in constraint.root.relations
-                if r.primaryCoding
-                and (
-                    r.primaryCoding.code.root == Relation.LIFTOVER_TO.value
-                    and r.primaryCoding.system == SystemUri.GKS_ALLELE_RELATION.value
-                )
-            )
-            != 1
-        ):
-            err_msg = f"Must contain exactly one relation where `primaryCoding.code` is '{Relation.LIFTOVER_TO.value}' and `primaryCoding.system` is '{SystemUri.GKS_ALLELE_RELATION.value}'."
-            raise ValueError(err_msg)
-
-        if (
-            sum(
-                1
-                for r in constraint.root.relations
-                if r.primaryCoding
-                and (
-                    r.primaryCoding.code.root == Relation.TRANSCRIBED_TO.value
-                    and r.primaryCoding.system == SystemUri.SEQUENCE_ONTOLOGY.value
-                )
-            )
-            != 1
-        ):
-            err_msg = f"Must contain exactly one relation where `primaryCoding.code` is '{Relation.TRANSCRIBED_TO.value}' and `primaryCoding.system` is '{SystemUri.SEQUENCE_ONTOLOGY.value}'."
-            raise ValueError(err_msg)
+        for required_relation in cls.required_relations():
+            if sum(1 for r in constraint.root.relations if r == required_relation) != 1:
+                err_msg = f"Must contain exactly one relation where `primaryCoding.code` is '{required_relation.primaryCoding.code.root}' and `primaryCoding.system` is '{required_relation.primaryCoding.system}'."
+                raise ValueError(err_msg)
 
         return v
 
@@ -162,48 +138,38 @@ class CategoricalCnv(CategoricalVariant):
 
         ``constraints`` must contain two constraints:
             1. ``DefiningLocationConstraint`` where the ``relations`` property contains
-                at least one relation where ``primaryCoding.code = liftover_to`` and ``primaryCoding.system = ga4gh-gks-term:allele-relation``
+                at least one ``LIFTOVER_TO_RELATION``
             2. Either a ``CopyCountConstraint`` or ``CopyChangeCount``
 
         :param v: Constraints property to validate
         :raises ValueError: If constraints property does not satisfy the requirements
         :return: Constraints property
         """
-        def_loc_constr_found = False
-        def_loc_constr_valid = False
-        copy_constr_found = False
+        defining_location = None
+        copy_constraint_found = False
 
-        for constraint in v:
-            constraint = constraint.root
-            if not def_loc_constr_valid and isinstance(
-                constraint, DefiningLocationConstraint
-            ):
-                def_loc_constr_found = True
+        for constraint_ in v:
+            constraint = constraint_.root
 
-                relations = constraint.relations or []
-                for r in relations:
-                    if r.primaryCoding and (
-                        r.primaryCoding.code.root == Relation.LIFTOVER_TO.value
-                        and r.primaryCoding.system
-                        == SystemUri.GKS_ALLELE_RELATION.value
-                    ):
-                        def_loc_constr_valid = True
-                        continue
+            if isinstance(constraint, DefiningLocationConstraint):
+                defining_location = constraint
+                continue
 
-            if not copy_constr_found:
-                copy_constr_found = isinstance(
-                    constraint, CopyCountConstraint | CopyChangeConstraint
-                )
+            if isinstance(constraint, CopyCountConstraint | CopyChangeConstraint):
+                copy_constraint_found = True
 
-        if not def_loc_constr_found:
-            err_msg = f"Must contain a `DefiningLocationConstraint` with at least one relation where `primaryCoding.code` is '{Relation.LIFTOVER_TO.value}' and `primaryCoding.system` is '{SystemUri.GKS_ALLELE_RELATION.value}'."
+        liftover_relation_missing_msg = f"at least one relation where `primaryCoding.code` is '{LIFTOVER_TO_RELATION.primaryCoding.code.root}' and `primaryCoding.system` is '{LIFTOVER_TO_RELATION.primaryCoding.system}'."
+
+        if not defining_location:
+            err_msg = f"Must contain a `DefiningLocationConstraint` with {liftover_relation_missing_msg}."
             raise ValueError(err_msg)
 
-        if not def_loc_constr_valid:
-            err_msg = f"`DefiningLocationConstraint` found, but must contain at least one relation where `primaryCoding.code` is '{Relation.LIFTOVER_TO.value}' and `primaryCoding.system` is '{SystemUri.GKS_ALLELE_RELATION.value}'."
+        relations = defining_location.relations or []
+        if not any(r == LIFTOVER_TO_RELATION for r in relations):
+            err_msg = f"`DefiningLocationConstraint` found, but must contain {liftover_relation_missing_msg}"
             raise ValueError(err_msg)
 
-        if not copy_constr_found:
+        if not copy_constraint_found:
             err_msg = (
                 "Must contain either a `CopyCountConstraint` or `CopyChangeConstraint`."
             )

--- a/src/ga4gh/cat_vrs/relations.py
+++ b/src/ga4gh/cat_vrs/relations.py
@@ -1,0 +1,48 @@
+"""Define enums and constants for relations."""
+
+from enum import Enum
+
+from ga4gh.core.models import Coding, MappableConcept, code
+
+
+class Relation(str, Enum):
+    """Defined relationships between members of the categorical variant and the defining
+    context.
+    """
+
+    TRANSLATION_OF = "translation_of"
+    LIFTOVER_TO = "liftover_to"
+    TRANSCRIBED_TO = "transcribed_to"
+
+
+class SystemUri(str, Enum):
+    """Define constraints for systems used in relations"""
+
+    SEQUENCE_ONTOLOGY = "http://www.sequenceontology.org"
+    GKS_ALLELE_RELATION = "ga4gh-gks-term:allele-relation"
+
+
+def _build_relation_concept(relation: Relation, system: SystemUri) -> MappableConcept:
+    """Create a relation concept
+
+    :param relation: Relation enum to describe the relationship
+    :param system: The system that defines the relation
+    :return: Mappable Concept representing the relation
+    """
+    return MappableConcept(
+        primaryCoding=Coding(
+            code=code(relation.value),
+            system=system.value,
+        )
+    )
+
+
+TRANSLATION_OF_RELATION = _build_relation_concept(
+    Relation.TRANSLATION_OF, SystemUri.SEQUENCE_ONTOLOGY
+)
+LIFTOVER_TO_RELATION = _build_relation_concept(
+    Relation.LIFTOVER_TO, SystemUri.GKS_ALLELE_RELATION
+)
+TRANSCRIBED_TO_RELATION = _build_relation_concept(
+    Relation.TRANSCRIBED_TO, SystemUri.SEQUENCE_ONTOLOGY
+)

--- a/tests/validation/test_cat_vrs_models.py
+++ b/tests/validation/test_cat_vrs_models.py
@@ -5,6 +5,11 @@ from copy import deepcopy
 import pytest
 
 from ga4gh.cat_vrs import models, recipes
+from ga4gh.cat_vrs.relations import (
+    LIFTOVER_TO_RELATION,
+    TRANSCRIBED_TO_RELATION,
+    TRANSLATION_OF_RELATION,
+)
 from ga4gh.core.models import (
     Coding,
     MappableConcept,
@@ -43,14 +48,7 @@ def members_and_name():
 def defining_loc_constr():
     """Create test fixture for defining location constraint"""
     return models.DefiningLocationConstraint(
-        relations=[
-            MappableConcept(
-                primaryCoding=Coding(
-                    code=code(models.Relation.LIFTOVER_TO.value),
-                    system="ga4gh-gks-term:allele-relation",
-                )
-            )
-        ],
+        relations=[LIFTOVER_TO_RELATION],
         location="location.json#/1",
         matchCharacteristic=MappableConcept(name="test"),
     )
@@ -89,14 +87,7 @@ def test_protein_sequence_consequence(defining_loc_constr, members_and_name):
     valid_params["constraints"] = [
         models.Constraint(
             root=models.DefiningAlleleConstraint(
-                relations=[
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.TRANSLATION_OF.value),
-                            system="http://www.sequenceontology.org",
-                        )
-                    )
-                ],
+                relations=[TRANSLATION_OF_RELATION],
                 allele=DUMMY_ALLELE_IRI,
             )
         )
@@ -131,7 +122,7 @@ def test_protein_sequence_consequence(defining_loc_constr, members_and_name):
     invalid_params["constraints"] = [
         models.Constraint(
             root=models.DefiningAlleleConstraint(
-                relations=[MappableConcept(name=models.Relation.LIFTOVER_TO.value)],
+                relations=[MappableConcept(name="liftover_to")],
                 allele=DUMMY_ALLELE_IRI,
             )
         )
@@ -144,14 +135,7 @@ def test_protein_sequence_consequence(defining_loc_constr, members_and_name):
     invalid_params["constraints"] = [
         models.Constraint(
             root=models.DefiningAlleleConstraint(
-                relations=[
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.LIFTOVER_TO.value),
-                            system="http://www.sequenceontology.org",
-                        )
-                    )
-                ],
+                relations=[LIFTOVER_TO_RELATION],
                 allele=DUMMY_ALLELE_IRI,
             )
         )
@@ -164,20 +148,7 @@ def test_protein_sequence_consequence(defining_loc_constr, members_and_name):
     invalid_params["constraints"] = [
         models.Constraint(
             root=models.DefiningAlleleConstraint(
-                relations=[
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.TRANSLATION_OF.value),
-                            system="http://www.sequenceontology.org",
-                        )
-                    ),
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.TRANSLATION_OF.value),
-                            system="http://www.sequenceontology.org",
-                        )
-                    ),
-                ],
+                relations=[TRANSLATION_OF_RELATION, TRANSLATION_OF_RELATION],
                 allele=DUMMY_ALLELE_IRI,
             )
         )
@@ -193,20 +164,7 @@ def test_canonical_allele(defining_loc_constr, members_and_name):
     valid_params["constraints"] = [
         models.Constraint(
             root=models.DefiningAlleleConstraint(
-                relations=[
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.LIFTOVER_TO.value),
-                            system="ga4gh-gks-term:allele-relation",
-                        )
-                    ),
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.TRANSCRIBED_TO.value),
-                            system="http://www.sequenceontology.org",
-                        )
-                    ),
-                ],
+                relations=[LIFTOVER_TO_RELATION, TRANSCRIBED_TO_RELATION],
                 allele=DUMMY_ALLELE_IRI,
             )
         )
@@ -242,20 +200,7 @@ def test_canonical_allele(defining_loc_constr, members_and_name):
     valid_params["constraints"] = [
         models.Constraint(
             root=models.DefiningAlleleConstraint(
-                relations=[
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.TRANSCRIBED_TO.value),
-                            system="http://www.sequenceontology.org",
-                        )
-                    ),
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.TRANSCRIBED_TO.value),
-                            system="http://www.sequenceontology.org",
-                        )
-                    ),
-                ],
+                relations=[TRANSCRIBED_TO_RELATION, TRANSCRIBED_TO_RELATION],
                 allele=DUMMY_ALLELE_IRI,
             )
         )
@@ -272,24 +217,9 @@ def test_canonical_allele(defining_loc_constr, members_and_name):
         models.Constraint(
             root=models.DefiningAlleleConstraint(
                 relations=[
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.LIFTOVER_TO.value),
-                            system="ga4gh-gks-term:allele-relation",
-                        )
-                    ),
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.LIFTOVER_TO.value),
-                            system="ga4gh-gks-term:allele-relation",
-                        )
-                    ),
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.TRANSCRIBED_TO.value),
-                            system="http://www.sequenceontology.org",
-                        )
-                    ),
+                    LIFTOVER_TO_RELATION,
+                    LIFTOVER_TO_RELATION,
+                    TRANSCRIBED_TO_RELATION,
                 ],
                 allele=DUMMY_ALLELE_IRI,
             )
@@ -307,18 +237,8 @@ def test_canonical_allele(defining_loc_constr, members_and_name):
         models.Constraint(
             root=models.DefiningAlleleConstraint(
                 relations=[
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.LIFTOVER_TO.value),
-                            system="http://www.sequenceontology.org",
-                        )
-                    ),
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.TRANSLATION_OF.value),
-                            system="http://www.sequenceontology.org",
-                        )
-                    ),
+                    LIFTOVER_TO_RELATION,
+                    TRANSLATION_OF_RELATION,
                 ],
                 allele=DUMMY_ALLELE_IRI,
             )
@@ -326,7 +246,7 @@ def test_canonical_allele(defining_loc_constr, members_and_name):
     ]
     with pytest.raises(
         ValueError,
-        match="Must contain exactly one relation where `primaryCoding.code` is 'liftover_to' and `primaryCoding.system` is 'ga4gh-gks-term:allele-relation'.",
+        match="Must contain exactly one relation where `primaryCoding.code` is 'transcribed_to' and `primaryCoding.system` is 'http://www.sequenceontology.org'.",
     ):
         recipes.CanonicalAllele(**valid_params)
 
@@ -336,24 +256,9 @@ def test_canonical_allele(defining_loc_constr, members_and_name):
         models.Constraint(
             root=models.DefiningAlleleConstraint(
                 relations=[
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.LIFTOVER_TO.value),
-                            system="ga4gh-gks-term:allele-relation",
-                        )
-                    ),
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.TRANSCRIBED_TO.value),
-                            system="http://www.sequenceontology.org",
-                        )
-                    ),
-                    MappableConcept(
-                        primaryCoding=Coding(
-                            code=code(models.Relation.TRANSCRIBED_TO.value),
-                            system="http://www.sequenceontology.org",
-                        )
-                    ),
+                    LIFTOVER_TO_RELATION,
+                    TRANSCRIBED_TO_RELATION,
+                    TRANSCRIBED_TO_RELATION,
                 ],
                 allele=DUMMY_ALLELE_IRI,
             )
@@ -420,7 +325,7 @@ def test_categorical_cnv(
     invalid_defining_loc_constr.relations = [
         MappableConcept(
             primaryCoding=Coding(
-                code=code(models.Relation.TRANSCRIBED_TO.value),
+                code=code("transcribed_to"),
                 system="ga4gh-gks-term:allele-relation",
             )
         )


### PR DESCRIPTION
close #42

* Move enums `Relation` and `SystemUri` to `relations` module
* Add `required_relations` method to `ProteinSequenceConsequence` and `CanonicalAllele`
* Clean up validator code