### PR TITLE
build: bump ga4gh.vrs version to ~=2.4.0a1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
-    "ga4gh.vrs~=2.4.0a0",
+    "ga4gh.vrs~=2.4.0a1",
     "pydantic>=2.0,<3.0",
 ]
 


### PR DESCRIPTION
Once this is merged, will make a `0.8.0-a1` release